### PR TITLE
replaced undescores with asterisks and removed duplicate operator

### DIFF
--- a/docs/src/en/comments.md
+++ b/docs/src/en/comments.md
@@ -19,7 +19,7 @@ In this example, the comment text "This line will be ignored by the Nuru interpr
 
 ## Multi-Line Comments
 
-Multi-line comments are used to provide more detailed explanations or documentation for multiple lines of code. To write a multi-line comment in Nuru, use a forward slash followed by an asterisk ( /_ ) to start the comment, and an asterisk followed by a forward slash ( _/ ) to end the comment. Here's an example:
+Multi-line comments are used to provide more detailed explanations or documentation for multiple lines of code. To write a multi-line comment in Nuru, use a forward slash followed by an asterisk ( /* ) to start the comment, and an asterisk followed by a forward slash ( */ ) to end the comment. Here's an example:
 
 ```go
 /*

--- a/docs/src/en/operators.md
+++ b/docs/src/en/operators.md
@@ -16,7 +16,6 @@ Assuming `i` and `v` are predefined variables, Nuru supports the following assig
 - `i -= v`: which is the equivalent of `i = i - v`
 - `i *= v`: which is the equivalent of `i = i * v`
 - `i /= v`: which is the equivalent of `i = i / v`
-- `i += v`: which is the equivalent of `i = i + v`
 
 For `strings`, `arrays` and `dictionaries`, the `+=` sign operator is permissible. Example:
 


### PR DESCRIPTION
Replaced the underscores (_) in the comments.md file with asterisks and removed the duplicate operator in the operators page 