### PR TITLE
Correct typo mistake

### DIFF
--- a/docs/src/buliani.md
+++ b/docs/src/buliani.md
@@ -56,7 +56,7 @@ andika(kweli && sikweli) // Tokeo: `sikweli`
 
 ### Kitendakazi `||`
 
-Kitendakazi || hutathmini kwenda to kweli kama angalau kitu kimoja kati ya vyote vinavyohusika ni kweli. Kwa mfano:
+Kitendakazi || hutathmini kwenda kweli kama angalau kitu kimoja kati ya vyote vinavyohusika ni kweli. Kwa mfano:
 
 ```go
 andika(kweli || sikweli) // Tokeo: `kweli`


### PR DESCRIPTION
This commit corrects a typo mistake.The phrase "kwenda to kweli" has an extra "to" which has been removed to make it correct.This will improve the clarity of the documentation.