### PR TITLE
Fix typo: Corrected 'ndania' to 'ndani'

### DIFF
--- a/docs/src/tungo.md
+++ b/docs/src/tungo.md
@@ -51,7 +51,7 @@ a *= 4
 
 ## Kuzunguka ndani ya tungo
 
-Unaweza kuzunguka ndania ya tungo kwa kutumia neno-msingi la `kwa`:
+Unaweza kuzunguka ndani ya tungo kwa kutumia neno-msingi la `kwa`:
 
 ```go
 fanya jina = "avicenna"


### PR DESCRIPTION
The commit fixes a minor typo in the Swahili sentence, replacing "ndania" with the correct spelling "ndani." This ensures the accuracy and clarity of the sentence in the codebase or document where it is used.