### PR TITLE
Corrected typo: changed 'hukanisha' to 'hukanusha

### DIFF
--- a/docs/src/buliani.md
+++ b/docs/src/buliani.md
@@ -66,7 +66,7 @@ andika(sikweli || sikweli) // Tokeo: `sikweli`
 
 ### Kitendakazi `!`
 
-Kitendakazi `!` hukanisha thamani ya kitu. Kwa mfano:
+Kitendakazi `!` hukanusha thamani ya kitu. Kwa mfano:
 
 ```go
 andika(!kweli) // Tokeo: `sikweli`


### PR DESCRIPTION
This commit corrects a spelling error in the Nuru programming language doc. The word "hukanisha" was previously used, but the correct Swahili spelling is "hukanusha". This change ensures that the codebase is consistent and accurate.